### PR TITLE
Use original filename of artifact, especially for artifacts with a classifier

### DIFF
--- a/sonar-packaging-maven-plugin/src/it/classifierDep/pom.xml
+++ b/sonar-packaging-maven-plugin/src/it/classifierDep/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.sonar</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>sonar-plugin</packaging>
+
+  <name>Basic</name>
+  <description>Plugin description.</description>
+  <url>http://sonar-plugins.codehaus.org</url>
+  <organization>
+    <name>SonarSource</name>
+    <url>http://www.sonarsource.com</url>
+  </organization>
+
+  <properties>
+    <sonar.version>@sonar.version@</sonar.version>
+
+    <!-- sonar.pluginKey = project.artifactId by default -->
+    <sonar.pluginKey>test</sonar.pluginKey>
+    <!-- sonar.pluginName = project.name by default -->
+    <sonar.pluginName>Test Plugin</sonar.pluginName>
+    <sonar.pluginCategory>Test</sonar.pluginCategory>
+    <sonar.pluginClass>org.sonar.plugins.sample.SamplePlugin</sonar.pluginClass>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.sonar</groupId>
+      <artifactId>sonar-plugin-api</artifactId>
+      <version>${sonar.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- same deps, one with classifier -->
+    <dependency>
+        <groupId>net.sourceforge.saxon</groupId>
+        <artifactId>saxon</artifactId>
+        <version>9.1.0.8</version>
+    </dependency>
+    <dependency>
+        <groupId>net.sourceforge.saxon</groupId>
+        <artifactId>saxon</artifactId>
+        <version>9.1.0.8</version>
+        <classifier>xpath</classifier>
+    </dependency>
+    
+
+    <!-- unit tests -->
+    <dependency>
+      <groupId>org.codehaus.sonar</groupId>
+      <artifactId>sonar-testing-harness</artifactId>
+      <version>${sonar.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.1</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/sonar-packaging-maven-plugin/src/it/classifierDep/src/main/java/org/sonar/plugins/sample/SamplePlugin.java
+++ b/sonar-packaging-maven-plugin/src/it/classifierDep/src/main/java/org/sonar/plugins/sample/SamplePlugin.java
@@ -1,0 +1,30 @@
+package org.sonar.plugins.sample;
+
+import org.sonar.api.Extension;
+import org.sonar.api.Plugin;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SamplePlugin implements Plugin {
+  public String getKey() {
+    return "sample";
+  }
+
+  public String getName() {
+    return "My first Sonar plugin";
+  }
+
+  public String getDescription() {
+    return "You shouldn't expect too much from this plugin.";
+  }
+
+  public List<Class<? extends Extension>> getExtensions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toString() {
+    return getKey();
+  }
+}

--- a/sonar-packaging-maven-plugin/src/it/classifierDep/verify.bsh
+++ b/sonar-packaging-maven-plugin/src/it/classifierDep/verify.bsh
@@ -1,0 +1,15 @@
+import java.io.*;
+
+File file;
+
+file = new File( basedir, "target/test-1.0/META-INF/lib/saxon-9.1.0.8.jar" );
+if ( !file.isFile() )
+{
+    throw new FileNotFoundException( "Could not find included JAR: " + file );
+}
+
+file = new File( basedir, "target/test-1.0/META-INF/lib/saxon-9.1.0.8-xpath.jar" );
+if ( !file.isFile() )
+{
+    throw new FileNotFoundException( "Could not find included JAR: " + file );
+}

--- a/sonar-packaging-maven-plugin/src/main/java/org/sonar/updatecenter/mavenplugin/SonarPluginMojo.java
+++ b/sonar-packaging-maven-plugin/src/main/java/org/sonar/updatecenter/mavenplugin/SonarPluginMojo.java
@@ -323,7 +323,7 @@ public class SonarPluginMojo extends AbstractSonarPluginMojo {
   }
 
   private String getDefaultFinalName(Artifact artifact) {
-    return artifact.getArtifactId() + "-" + artifact.getVersion() + "." + artifact.getArtifactHandler().getExtension();
+    return artifact.getFile().getName();
   }
 
   private Set<Artifact> getNotProvidedDependencies() throws DependencyTreeBuilderException {


### PR DESCRIPTION
I've attached an integration-test showing an issue we have. Even though I'm convinced that the xpath-classified jar should have been a  separate artifact, the situation is as it is. What currently happens is that the first artifact is copied with artifact+version+extension as filename. Next the classified jar is copied with exactly the same name, causing an overwrite.
I think you can safely use the original filename. Only with SNAPSHOTs you could get a timestamped version, but that doesn't have to be a problem. You could add a boolean parameter uniqueVersion, which uses either the artifact.getVersion() or artifact.getBaseVersion()