### PR TITLE
Support marking plugins as now "bundled"

### DIFF
--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Plugin.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Plugin.java
@@ -27,6 +27,7 @@ public class Plugin extends Component {
 
 
   private boolean supportedBySonarSource = false;
+  private boolean bundled = false;
 
 
   private Plugin(String key) {
@@ -47,6 +48,10 @@ public class Plugin extends Component {
     return supportedBySonarSource;
   }
 
+  public boolean isBundled() {
+    return bundled;
+  }
+
   @Override
   boolean needArtifact() {
     return true;
@@ -60,6 +65,11 @@ public class Plugin extends Component {
 
   public Plugin setSupportedBySonarSource(boolean supportedBySonarSource) {
     this.supportedBySonarSource = supportedBySonarSource;
+    return this;
+  }
+
+  public Plugin setBundled(boolean bundled) {
+    this.bundled = bundled;
     return this;
   }
 

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
@@ -263,6 +263,7 @@ public final class UpdateCenterDeserializer {
 
       parseComponent(p, sonar, pluginKey, plugin);
       plugin.setSupportedBySonarSource(Boolean.valueOf(get(p, pluginKey, "supportedBySonarSource", false)));
+      plugin.setBundled(Boolean.valueOf(get(p, pluginKey, "bundled", false)));
 
       // do not add plugin without any version
       if (!plugin.getAllReleases().isEmpty()) {

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
@@ -63,6 +63,7 @@ public class UpdateCenterDeserializerTest {
       assertThat(clirr.getDescription()).isEqualTo("Clirr Plugin");
       assertThat(clirr.getIssueTrackerUrl()).isEqualTo("http://jira.codehaus.org/issueTracker/for/clirr");
       assertThat(clirr.isSupportedBySonarSource()).isTrue();
+      assertThat(clirr.isBundled()).isTrue();
       assertThat(clirr.getVersions()).contains(Version.create("1.0"), Version.create("1.1"));
 
       assertThat(clirr.getSourcesUrl()).isNull();
@@ -78,6 +79,7 @@ public class UpdateCenterDeserializerTest {
 
       Plugin motionchart = center.getUpdateCenterPluginReferential().findPlugin("motionchart");
       assertThat(motionchart.isSupportedBySonarSource()).isFalse();
+      assertThat(motionchart.isBundled()).isFalse();
       assertThat(motionchart.getRelease(Version.create("1.7")).getDisplayVersion()).isNull();
     }
   }
@@ -293,6 +295,7 @@ public class UpdateCenterDeserializerTest {
 
     Plugin phpPlugin = center.getUpdateCenterPluginReferential().findPlugin("php");
     assertThat(phpPlugin.isSupportedBySonarSource()).isTrue();
+    assertThat(phpPlugin.isBundled()).isTrue();
     assertThat(phpPlugin.getDevRelease().getVersion()).isEqualTo(Version.create("2.3-SNAPSHOT"));
     assertThat(phpPlugin.getPublicVersions()).extracting(Version::getName).containsOnly("2.1", "2.2");
     assertThat(phpPlugin.getPrivateVersions()).extracting(Version::getName).containsOnly("2.2.1");

--- a/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/splitFileFormat/nominal/abap.properties
+++ b/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/splitFileFormat/nominal/abap.properties
@@ -7,6 +7,7 @@ publicVersions=2.1,2.2
 description=ABAP
 category=Languages
 supportedBySonarSource=true
+bundled=true
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins
 defaults.mavenArtifactId=sonar-abap-plugin

--- a/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/splitFileFormat/nominal/php.properties
+++ b/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/splitFileFormat/nominal/php.properties
@@ -11,6 +11,7 @@ archivedVersions=2.0
 description=PHP
 category=Languages
 supportedBySonarSource=true
+bundled=true
 
 defaults.mavenGroupId=org.codehaus.sonar-plugins
 defaults.mavenArtifactId=sonar-php-plugin

--- a/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/updates.properties
+++ b/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/updates.properties
@@ -27,6 +27,7 @@ clirr.publicVersions=1.0,1.1
 clirr.defaults.mavenGroupId=org.codehaus.sonar-plugins
 clirr.defaults.mavenArtifactId=sonar-clirr-plugin
 clirr.supportedBySonarSource=true
+clirr.bundled=true
 
 clirr.1.0.downloadUrl=http://dist.sonar-plugins.codehaus.org/clirr-1.0.jar
 clirr.1.0.displayVersion=1.0

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/CompatibilityMatrix.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/CompatibilityMatrix.java
@@ -70,7 +70,7 @@ public class CompatibilityMatrix {
       Map<String, Object> dataModel = new HashMap<>();
       dataModel.put("pluginHeader", pluginModel);
 
-      CompatibilityMatrix.Plugin matrixPlugin = new CompatibilityMatrix.Plugin(plugin.getName(), plugin.getHomepageUrl(), plugin.isSupportedBySonarSource());
+      CompatibilityMatrix.Plugin matrixPlugin = new CompatibilityMatrix.Plugin(plugin.getName(), plugin.getHomepageUrl(), plugin.isSupportedBySonarSource(), plugin.isBundled());
       getPlugins().add(matrixPlugin);
 
       for (Release sq : center.getSonar().getMajorReleases()) {
@@ -108,11 +108,13 @@ public class CompatibilityMatrix {
     private final Map<String, String> compatibleVersionBySqVersion = new HashMap<>();
 
     private final boolean isSupportedBySonarSource;
+    private final boolean isBundled;
 
-    public Plugin(String name, String homepageUrl, boolean isSupportedBySonarSource) {
+    public Plugin(String name, String homepageUrl, boolean isSupportedBySonarSource, boolean isBundled) {
       this.name = name;
       this.homepageUrl = homepageUrl;
       this.isSupportedBySonarSource = isSupportedBySonarSource;
+      this.isBundled = isBundled;
     }
 
     public String getName() {
@@ -134,6 +136,10 @@ public class CompatibilityMatrix {
 
     public boolean isSupportedBySonarSource() {
       return isSupportedBySonarSource;
+    }
+
+    public boolean isBundled() {
+      return isBundled;
     }
   }
 

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginModel.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginModel.java
@@ -88,6 +88,10 @@ public class PluginModel {
     return plugin.isSupportedBySonarSource();
   }
 
+  public boolean isBundled() {
+    return plugin.isBundled();
+  }
+
   public boolean isSonarSourceCommercialPlugin() {
     return isSupportedBySonarSource() && StringUtils.isNotEmpty(plugin.getTermsConditionsUrl());
   }

--- a/sonar-update-center-mojo/src/main/resources/org/sonar/updatecenter/mojo/matrix-template.html.ftl
+++ b/sonar-update-center-mojo/src/main/resources/org/sonar/updatecenter/mojo/matrix-template.html.ftl
@@ -47,6 +47,8 @@
         <td>
           <#if plugin.supports(sqVersion.realVersion) >
           ${plugin.supportedVersion(sqVersion.realVersion)}
+          <#elseif plugin.isBundled()>
+        Bundled
           <#else>
           <img class="emoticon" alt="(not compatible)" src="error.png" />
           </#if>

--- a/sonar-update-center-mojo/src/main/resources/org/sonar/updatecenter/mojo/matrix-template.html.ftl
+++ b/sonar-update-center-mojo/src/main/resources/org/sonar/updatecenter/mojo/matrix-template.html.ftl
@@ -48,7 +48,7 @@
           <#if plugin.supports(sqVersion.realVersion) >
           ${plugin.supportedVersion(sqVersion.realVersion)}
           <#elseif plugin.isBundled()>
-        Bundled
+          Bundled
           <#else>
           <img class="emoticon" alt="(not compatible)" src="error.png" />
           </#if>

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/CompatibilityMatrixTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/CompatibilityMatrixTest.java
@@ -45,9 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class CompatibilityMatrixTest {
-
-  private final static String PLUGIN_KEY = "key";
-
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -75,7 +72,7 @@ public class CompatibilityMatrixTest {
     sonar.setLtsRelease("3.7.4");
   }
 
-  private void prepareMocks(Plugin... plugins) throws IOException {
+  private void prepareMocks(Plugin... plugins) {
     pluginReferential = plugins.length > 0 ? PluginReferential.create(asList(plugins)) : PluginReferential.createEmpty();
     center = UpdateCenter.create(pluginReferential, new ArrayList<>(), sonar);
     matrix = new CompatibilityMatrix(center, outputFolder, mock(Log.class));
@@ -98,18 +95,37 @@ public class CompatibilityMatrixTest {
 
   @Test
   public void shouldGenerateHtml() throws Exception {
-    Plugin plugin = Plugin.factory(PLUGIN_KEY);
-    Version version = Version.create("1.0");
-    Release release = new Release(plugin, version);
-    release.setDate(getDate());
-    release.setDownloadUrl("http://valid.download.url");
-    release.addRequiredSonarVersions("3.0");
-    plugin.addRelease(release);
-    plugin.setName("name");
-    plugin.setLicense("licence");
-    plugin.setSupportedBySonarSource(true);
+    Plugin pluginFoo = Plugin.factory("foo");
+    Version versionFoo = Version.create("1.0");
+    Release releaseFoo = new Release(pluginFoo, versionFoo);
+    releaseFoo.setDate(getDate());
+    releaseFoo.setDownloadUrl("http://valid.download.url");
+    releaseFoo.addRequiredSonarVersions("3.0");
+    pluginFoo.addRelease(releaseFoo);
+    pluginFoo.setName("foo");
+    pluginFoo.setSupportedBySonarSource(true);
 
-    prepareMocks(plugin);
+    Plugin pluginBar = Plugin.factory("bar");
+    Version versionBar = Version.create("2.0");
+    Release releaseBar = new Release(pluginBar, versionBar);
+    releaseBar.setDate(getDate());
+    releaseBar.setDownloadUrl("http://other.download.url");
+    releaseBar.addRequiredSonarVersions("4.0");
+    pluginBar.addRelease(releaseBar);
+    pluginBar.setName("bar");
+
+    Plugin pluginAbap = Plugin.factory("abap");
+    Version versionAbap = Version.create("5.2");
+    Release releaseAbap = new Release(pluginAbap, versionAbap);
+    releaseAbap.setDate(getDate());
+    releaseAbap.setDownloadUrl("http://abap.download.url");
+    releaseAbap.addRequiredSonarVersions("3.0");
+    pluginAbap.addRelease(releaseAbap);
+    pluginAbap.setName("abap");
+    pluginAbap.setSupportedBySonarSource(true);
+    pluginAbap.setBundled(true);
+
+    prepareMocks(pluginFoo, pluginBar, pluginAbap);
     matrix.generateHtml();
 
     // 4 files:

--- a/sonar-update-center-mojo/src/test/resources/org/sonar/updatecenter/mojo/CompatibilityMatrixTest/compatibility-matrix.html
+++ b/sonar-update-center-mojo/src/test/resources/org/sonar/updatecenter/mojo/CompatibilityMatrixTest/compatibility-matrix.html
@@ -30,7 +30,24 @@
     <tbody>
     <tr>
         <td>
-            <strong>name</strong>
+            <strong>abap</strong>
+            <img class="emoticon" alt="(Supported by SonarSource)" src="onde-sonar-16.png" />
+        </td>
+        <td>5.2</td>
+        <td>Bundled</td>
+        <td>Bundled</td>
+    </tr>
+    <tr>
+        <td>
+            <strong>bar</strong>
+        </td>
+        <td><img class="emoticon" alt="(notcompatible)" src="error.png" /></td>
+        <td><img class="emoticon" alt="(notcompatible)" src="error.png" /></td>
+        <td>2.0</td>
+    </tr>
+    <tr>
+        <td>
+            <strong>foo</strong>
             <img class="emoticon" alt="(Supported by SonarSource)" src="onde-sonar-16.png" />
         </td>
         <td>1.0</td>


### PR DESCRIPTION
This pull request supports marking a plugin as `bundled` in its `sonar-update-center-properties` definition, which will add the word "Bundled" in place of the red X when no compatible version is found but `bundled` is set. :D

<img width="1493" alt="Screenshot 2021-03-04 at 12 03 27" src="https://user-images.githubusercontent.com/44168128/109954452-a3a64200-7ce1-11eb-92e8-f8fde1ba861e.png">

(This PR was mostly an educational experiment that started to work so.... maybe we can really consider it?)

It's related to this thread: https://discuss.sonarsource.com/t/plugin-version-matrix-incompatible-plugins-confusion/7084/4