### PR TITLE
UPC-116 Remove dependency on legacy plugins for Compatibility Matrix Generation

### DIFF
--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferential.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferential.java
@@ -31,6 +31,7 @@ import org.sonar.updatecenter.common.exception.PluginNotFoundException;
 
 public class PluginReferential {
 
+  public static final String PLUGIN_LICENSE_KEY = "license";
   private Set<Plugin> plugins;
 
   private PluginReferential() {
@@ -102,6 +103,15 @@ public class PluginReferential {
   }
 
   public void addOutgoingDependency(Release release, String requiredPluginReleaseKey, String requiredMinimumReleaseVersion) {
+
+    // skip dependencies on license, as it's deprecated and is provided by SQ anyway. There is no need
+    // to have the explicit dependency on the update center side.
+    // Once every analyzers remove the dependency on 'license' on their metadata, we will be able to remove
+    // this guard condition
+    if(PLUGIN_LICENSE_KEY.equals(requiredPluginReleaseKey)){
+      return;
+    }
+
     try {
       Plugin requiredPlugin = findPlugin(requiredPluginReleaseKey);
       Release minimalRequiredRelease = requiredPlugin.getMinimalRelease(Version.create(requiredMinimumReleaseVersion));

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialTest.java
@@ -28,7 +28,9 @@ import org.sonar.updatecenter.common.exception.PluginNotFoundException;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.sonar.updatecenter.common.PluginReferential.PLUGIN_LICENSE_KEY;
 
 public class PluginReferentialTest {
 
@@ -100,6 +102,23 @@ public class PluginReferentialTest {
     PluginReferential pluginReferential = PluginReferential.create(asList(bar, foo));
     pluginReferential.addOutgoingDependency(bar10, "foo", "1.0");
     assertThat(pluginReferential.findPlugin("bar").getRelease(Version.create("1.0")).getOutgoingDependencies().iterator().next().getVersion().getName()).isEqualTo("1.0");
+  }
+
+
+  @Test
+  public void ignore_add_license_dependency() {
+    Plugin licensePlugin = Plugin.factory(PLUGIN_LICENSE_KEY);
+    Release licenseRelease = new Release(licensePlugin, "1.0");
+    licensePlugin.addRelease(licenseRelease);
+
+    Plugin bar = Plugin.factory("bar");
+    Release bar10 = new Release(bar, "1.0");
+    bar.addRelease(bar10);
+
+    Version version = Version.create("1.0");
+    PluginReferential pluginReferential = PluginReferential.create(asList(bar, licensePlugin));
+    pluginReferential.addOutgoingDependency(bar10, PLUGIN_LICENSE_KEY, version.getName());
+    assertThat(pluginReferential.findPlugin("bar").getRelease(version).getOutgoingDependencies()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
relates to https://github.com/SonarSource/sonar-update-center-properties/pull/287, which needs to be merged at the same time.