### PR TITLE
BUILD-3788 fix promotion

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,6 +77,8 @@ promote_task:
     <<: *CONTAINER_DEFINITION
     cpu: 0.5
     memory: 500M
+  env:
+    GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
   maven_cache:
     folder: $CIRRUS_WORKING_DIR/.m2/repository
   script:


### PR DESCRIPTION
The promote_task is not using the proper GitHub token
- it should be the one suffixed `-promotion`
- it is using the `licenses-ro` token defined at top level

Workaround not applied: `unset GITHUB_TOKEN` before call to `cirrus_promote_maven`
Fix applied: use `development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion` token.