### PR TITLE
UPC-136 Remove unused env variable GCF_ACCESS_TOKEN and PROMOTE_URL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,9 +13,6 @@ env:
 
   CIRRUS_CLONE_DEPTH: 50
 
-  GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-  PROMOTE_URL: VAULT[development/kv/data/promote data.url]
-
   GITHUB_TOKEN: VAULT[development/github/token/licenses-ro token]
 
   BURGR_URL: VAULT[development/kv/data/burgr data.url]


### PR DESCRIPTION
All permissions to `development/kv/data/promote` were removed and the key was deleted from the vault which now makes the build fail because we still have unused shared variables depending on it.