### PR TITLE
UPC-165 Update timeless license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>86.0.0.3040</version>
+    <version>87.0.0.3057</version>
   </parent>
   
   <groupId>org.sonarsource.update-center</groupId>

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Artifact.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Artifact.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Component.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Component.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/FormatUtils.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/FormatUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Plugin.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Plugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginKeyUtils.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginKeyUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginManifest.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginManifest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferential.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferential.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferentialManifestConverter.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginReferentialManifestConverter.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginUpdate.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/PluginUpdate.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Product.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Product.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Scanner.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Scanner.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Sonar.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Sonar.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/SonarRelease.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/SonarRelease.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/SonarUpdate.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/SonarUpdate.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenter.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenter.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Version.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Version.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/DependencyCycleException.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/DependencyCycleException.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/IncompatiblePluginVersionException.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/IncompatiblePluginVersionException.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/PluginNotFoundException.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/PluginNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/SonarVersionRangeException.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/SonarVersionRangeException.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/package-info.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/exception/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/package-info.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ArtifactTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ArtifactTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ComponentTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ComponentTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/FormatUtilsTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/FormatUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginKeyUtilsTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginKeyUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginManifestTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginManifestTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialManifestConverterTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialManifestConverterTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginReferentialTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginUpdateTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/PluginUpdateTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ReleaseTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ScannerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ScannerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarReleaseTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarReleaseTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarUpdateTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/SonarUpdateTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/VersionTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/VersionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Common
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/CompatibilityMatrix.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/CompatibilityMatrix.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/Configuration.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/FreeMarkerUtils.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/FreeMarkerUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateHtmlMojo.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateHtmlMojo.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateJsonMojo.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateJsonMojo.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateMetadataMojo.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/GenerateMetadataMojo.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/Generator.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/Generator.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/HttpDownloader.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/HttpDownloader.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/JsonGenerator.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/JsonGenerator.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginModel.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginModel.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginsJsonGenerator.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/PluginsJsonGenerator.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ReleaseModel.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ReleaseModel.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ScannerJsonGenerator.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ScannerJsonGenerator.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ScannerModel.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/ScannerModel.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/SonarVersionModel.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/SonarVersionModel.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/package-info.java
+++ b/sonar-update-center-mojo/src/main/java/org/sonar/updatecenter/mojo/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/main/resources/styles.css
+++ b/sonar-update-center-mojo/src/main/resources/styles.css
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/CompatibilityMatrixTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/CompatibilityMatrixTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateHtmlMojoTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateHtmlMojoTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateJsonMojoTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateJsonMojoTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateMetadataMojoTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/GenerateMetadataMojoTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/HttpDownloaderTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/HttpDownloaderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/PluginsJsonGeneratorTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/PluginsJsonGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/ScannerJsonGeneratorTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/ScannerJsonGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/SonarVersionModelTest.java
+++ b/sonar-update-center-mojo/src/test/java/org/sonar/updatecenter/mojo/SonarVersionModelTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: Update Center :: Maven Plugin
- * Copyright (C) 2010-2025 SonarSource Sàrl
+ * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
## Summary
- Bump parent POM from 86.0.0.3040 to 87.0.0.3057
- Run `mvn license:format` to apply dateless headers (`Copyright (C) SonarSource Sàrl`, no year) across all 67 Java files and 1 CSS file

