### PR TITLE
SONAR-30893 Fix Quality Gate issue related to javabugs:S2259

### DIFF
--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
@@ -122,7 +122,7 @@ public class Release implements Comparable<Release> {
     return displayVersion;
   }
 
-  public Release setDisplayVersion(String displayVersion) {
+  public Release setDisplayVersion(@Nullable String displayVersion) {
     this.displayVersion = displayVersion;
     return this;
   }

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ReleaseTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/ReleaseTest.java
@@ -124,6 +124,13 @@ public class ReleaseTest {
   }
 
   @Test
+  public void should_allow_missing_display_version() {
+    Release release = new Release(Plugin.factory("squid"), "1.0");
+
+    assertThat(release.setDisplayVersion(null).getDisplayVersion()).isNull();
+  }
+
+  @Test
   public void supportSonarVersion_whenPaidSonarQubeSupported_shouldReturnTrue() {
     Release release = new Release(Plugin.factory("squid"), "1.0");
 


### PR DESCRIPTION
SONAR-30893 Fix the `javabugs:S2259` Quality Gate finding.

Declares `Release.setDisplayVersion`'s optional parameter as nullable and adds regression coverage for an absent display version.

Tests: `mvn -pl sonar-update-center-common -Dtest=ReleaseTest test`