### PR TITLE
UPC-172 next release cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   
   <groupId>org.sonarsource.update-center</groupId>
   <artifactId>sonar-update-center</artifactId>
-  <version>1.36-SNAPSHOT</version>
+  <version>1.37-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Sonar :: Update Center</name>
   <url>http://www.sonarsource.org</url>

--- a/sonar-update-center-common/pom.xml
+++ b/sonar-update-center-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.update-center</groupId>
     <artifactId>sonar-update-center</artifactId>
-    <version>1.36-SNAPSHOT</version>
+    <version>1.37-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-update-center-common</artifactId>

--- a/sonar-update-center-mojo/pom.xml
+++ b/sonar-update-center-mojo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.update-center</groupId>
     <artifactId>sonar-update-center</artifactId>
-    <version>1.36-SNAPSHOT</version>
+    <version>1.37-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-update-center-mojo</artifactId>
   <packaging>maven-plugin</packaging>


### PR DESCRIPTION
## Summary
- Bump version from `1.36-SNAPSHOT` to `1.37-SNAPSHOT` to open the next development iteration, so `1.36` can be released.

## Test plan
- No functional changes; version bump only, following the same pattern as #129.