### PR TITLE
SONAR-30893 next release cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   
   <groupId>org.sonarsource.update-center</groupId>
   <artifactId>sonar-update-center</artifactId>
-  <version>1.37-SNAPSHOT</version>
+  <version>1.38-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Sonar :: Update Center</name>
   <url>http://www.sonarsource.org</url>

--- a/sonar-update-center-common/pom.xml
+++ b/sonar-update-center-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.update-center</groupId>
     <artifactId>sonar-update-center</artifactId>
-    <version>1.37-SNAPSHOT</version>
+    <version>1.38-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-update-center-common</artifactId>

--- a/sonar-update-center-mojo/pom.xml
+++ b/sonar-update-center-mojo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.update-center</groupId>
     <artifactId>sonar-update-center</artifactId>
-    <version>1.37-SNAPSHOT</version>
+    <version>1.38-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-update-center-mojo</artifactId>
   <packaging>maven-plugin</packaging>


### PR DESCRIPTION
## Summary
- Bump version from `1.37-SNAPSHOT` to `1.38-SNAPSHOT` in `pom.xml`, `sonar-update-center-common/pom.xml`, and `sonar-update-center-mojo/pom.xml` to prepare the next development cycle after the 1.37 release.