### PR TITLE
SONAR-31598 Add premiumEolDate field to Release

### DIFF
--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Release.java
@@ -71,6 +71,7 @@ public class Release implements Comparable<Release> {
   private final SortedSet<Version> compatibleCommunitySqVersions;
   private Date date;
   private Date eolDate;
+  private Date premiumEolDate;
 
   public Release(Artifact artifact, Version version) {
     this.artifact = artifact;
@@ -276,6 +277,16 @@ public class Release implements Comparable<Release> {
 
   public Release setEolDate(@Nullable Date eolDate) {
     this.eolDate = eolDate != null ? new Date(eolDate.getTime()) : null;
+    return this;
+  }
+
+  @CheckForNull
+  public Date getPremiumEolDate() {
+    return premiumEolDate != null ? new Date(premiumEolDate.getTime()) : null;
+  }
+
+  public Release setPremiumEolDate(@Nullable Date premiumEolDate) {
+    this.premiumEolDate = premiumEolDate != null ? new Date(premiumEolDate.getTime()) : null;
     return this;
   }
 

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterDeserializer.java
@@ -50,6 +50,7 @@ public final class UpdateCenterDeserializer {
 
   public static final String DATE_SUFFIX = ".date";
   public static final String EOL_DATE_SUFFIX = ".eolDate";
+  public static final String PREMIUM_EOL_DATE_SUFFIX = ".premiumEolDate";
   public static final String DESCRIPTION_SUFFIX = ".description";
   public static final String MAVEN_GROUPID_SUFFIX = ".mavenGroupId";
   public static final String MAVEN_ARTIFACTID_SUFFIX = ".mavenArtifactId";
@@ -420,6 +421,7 @@ public final class UpdateCenterDeserializer {
         continue;
       }
       release.setEolDate(toDate(getOrDefault(properties, majorMinor, EOL_DATE_SUFFIX, false)));
+      release.setPremiumEolDate(toDate(getOrDefault(properties, majorMinor, PREMIUM_EOL_DATE_SUFFIX, false)));
       ltaVersions.add(release);
     }
     sonar.setLtaVersions(ltaVersions);

--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
@@ -37,6 +37,7 @@ import static org.sonar.updatecenter.common.UpdateCenterDeserializer.CHANGELOG_U
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.DATE_SUFFIX;
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.DESCRIPTION_SUFFIX;
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.EOL_DATE_SUFFIX;
+import static org.sonar.updatecenter.common.UpdateCenterDeserializer.PREMIUM_EOL_DATE_SUFFIX;
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.DISPLAY_VERSION_SUFFIX;
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.DOWNLOAD_URL_SUFFIX;
 import static org.sonar.updatecenter.common.UpdateCenterDeserializer.MAVEN_ARTIFACTID_SUFFIX;
@@ -101,11 +102,7 @@ public final class UpdateCenterSerializer {
     List<Release> ltaVersions = center.getSonar().getLtaVersions();
     if (!ltaVersions.isEmpty()) {
       set(p, "ltaVersions", ltaVersions.stream().map(UpdateCenterSerializer::toMajorMinor).toList());
-      for (Release ltaRelease : ltaVersions) {
-        if (ltaRelease.getEolDate() != null) {
-          set(p, toMajorMinor(ltaRelease) + EOL_DATE_SUFFIX, FormatUtils.toDateString(ltaRelease.getEolDate()));
-        }
-      }
+      ltaVersions.forEach(ltaRelease -> setLtaEolDates(p, ltaRelease));
     }
     for (Product product : Product.values()) {
       setProductProperties(center, p, product);
@@ -118,6 +115,15 @@ public final class UpdateCenterSerializer {
     }
     set(p, "plugins", pluginKeys);
     return p;
+  }
+
+  private static void setLtaEolDates(Properties p, Release ltaRelease) {
+    if (ltaRelease.getEolDate() != null) {
+      set(p, toMajorMinor(ltaRelease) + EOL_DATE_SUFFIX, FormatUtils.toDateString(ltaRelease.getEolDate()));
+    }
+    if (ltaRelease.getPremiumEolDate() != null) {
+      set(p, toMajorMinor(ltaRelease) + PREMIUM_EOL_DATE_SUFFIX, FormatUtils.toDateString(ltaRelease.getPremiumEolDate()));
+    }
   }
 
   private static String toMajorMinor(Release release) {

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterDeserializerTest.java
@@ -310,7 +310,9 @@ public class UpdateCenterDeserializerTest {
       List<Release> ltaVersions = center.getSonar().getLtaVersions();
       assertThat(ltaVersions).extracting(release -> release.getVersion().toString()).containsExactly("2025.4", "2026.1.1");
       assertThat(ltaVersions.get(0).getEolDate()).isEqualTo(FormatUtils.toDate("2026-08-01"));
-      assertThat(ltaVersions.get(1).getEolDate()).isEqualTo(FormatUtils.toDate("2027-07-01"));
+      assertThat(ltaVersions.get(0).getPremiumEolDate()).isNull();
+      assertThat(ltaVersions.get(1).getEolDate()).isEqualTo(FormatUtils.toDate("2027-01-27"));
+      assertThat(ltaVersions.get(1).getPremiumEolDate()).isEqualTo(FormatUtils.toDate("2027-08-01"));
 
       // legacy scalar fields are kept in sync with the list for consumers that haven't migrated yet
       assertThat(center.getSonar().getLtaVersion().getVersion()).isEqualTo(Version.create("2026.1.1"));

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
@@ -154,7 +154,8 @@ public class UpdateCenterSerializerTest {
     sonar.addRelease(currentLtaRelease);
 
     pastLtaRelease.setEolDate(FormatUtils.toDate("2026-08-01"));
-    currentLtaRelease.setEolDate(FormatUtils.toDate("2027-07-01"));
+    currentLtaRelease.setEolDate(FormatUtils.toDate("2027-01-27"));
+    currentLtaRelease.setPremiumEolDate(FormatUtils.toDate("2027-08-01"));
     sonar.setLtaVersions(Arrays.asList(pastLtaRelease, currentLtaRelease));
 
     PluginReferential pluginReferential = PluginReferential.create(new ArrayList<>());
@@ -163,7 +164,9 @@ public class UpdateCenterSerializerTest {
 
     assertProperty(properties, "ltaVersions", "2025.4,2026.1");
     assertProperty(properties, "2025.4.eolDate", "2026-08-01");
-    assertProperty(properties, "2026.1.eolDate", "2027-07-01");
+    assertThat(properties.getProperty("2025.4.premiumEolDate")).isNull();
+    assertProperty(properties, "2026.1.eolDate", "2027-01-27");
+    assertProperty(properties, "2026.1.premiumEolDate", "2027-08-01");
     // legacy scalar fields are kept in sync by the deserializer, not the serializer;
     // the serializer only writes whatever is set on Sonar#getLtaVersion()/getPastLtaVersion()
     assertThat(properties.getProperty("ltaVersion")).isNull();

--- a/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/sonar-lta-versions.properties
+++ b/sonar-update-center-common/src/test/resources/org/sonar/updatecenter/common/UpdateCenterDeserializerTest/sonar-lta-versions.properties
@@ -2,7 +2,8 @@ publicVersions=2025.1,2025.4,2025.5,2025.6,2026.1,2026.1.1,2026.2,2027.1
 ltsVersion=2026.1.1
 ltaVersions=2025.4,2026.1
 2025.4.eolDate=2026-08-01
-2026.1.eolDate=2027-07-01
+2026.1.eolDate=2027-01-27
+2026.1.premiumEolDate=2027-08-01
 
 defaults.description=Description
 


### PR DESCRIPTION
## What

Adds `premiumEolDate` support to the Update Center library so that premium/enterprise support customers (who have 18 months of version activeness instead of 12) can have their own distinct EOL date per LTA line.

Part of SONAR-31638 / SONAR-31598 / MMF-5708 — Update Center supports 2 LTAs in one year.

## What was done ?

- **`Release.java`**: new `premiumEolDate` field with `getPremiumEolDate()`/`setPremiumEolDate()` getters/setters, mirroring the existing `eolDate` implementation (defensive Date copy for immutability, `@CheckForNull`/`@Nullable` annotated).
- **`UpdateCenterDeserializer.java`**: new constant `PREMIUM_EOL_DATE_SUFFIX = ".premiumEolDate"`; parsed from properties alongside `eolDate` in `parseLtaVersions()`.
- **`UpdateCenterSerializer.java`**: writes `<major.minor>.premiumEolDate` when set, alongside `<major.minor>.eolDate`.
- **Tests**: updated `fromProperties_shouldParseLtaVersions` and `toProperties_shouldWriteLtaVersionsAndEolDates_whenLtaVersionsListIsSet` to assert round-trip of `premiumEolDate`.

## Not in scope

- `sonar-update-center-properties`: handled in a separate PR (adding actual `premiumEolDate` values for 2025.1 and 2026.1).
- SQS-side reading of `premiumEolDate` and license `support-type` field (SONAR-31638 / SONAR-31598 — separate sonar-enterprise PR).