### PR TITLE
SONAR-31598 Throw when premiumEolDate is set on non-LTA release

### DIFF
--- a/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
+++ b/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/UpdateCenterSerializer.java
@@ -104,6 +104,7 @@ public final class UpdateCenterSerializer {
       set(p, "ltaVersions", ltaVersions.stream().map(UpdateCenterSerializer::toMajorMinor).toList());
       ltaVersions.forEach(ltaRelease -> setLtaEolDates(p, ltaRelease));
     }
+    validateNoPremiumEolDateOnNonLtaReleases(center, ltaVersions);
     for (Product product : Product.values()) {
       setProductProperties(center, p, product);
     }
@@ -124,6 +125,20 @@ public final class UpdateCenterSerializer {
     if (ltaRelease.getPremiumEolDate() != null) {
       set(p, toMajorMinor(ltaRelease) + PREMIUM_EOL_DATE_SUFFIX, FormatUtils.toDateString(ltaRelease.getPremiumEolDate()));
     }
+  }
+
+  private static void validateNoPremiumEolDateOnNonLtaReleases(UpdateCenter center, List<Release> ltaVersions) {
+    Set<String> ltaMajorMinors = ltaVersions.stream()
+      .map(UpdateCenterSerializer::toMajorMinor)
+      .collect(Collectors.toSet());
+    center.getSonar().getReleases().stream()
+      .filter(release -> release.getPremiumEolDate() != null)
+      .filter(release -> !ltaMajorMinors.contains(toMajorMinor(release)))
+      .findFirst()
+      .ifPresent(release -> {
+        throw new IllegalStateException(
+          "premiumEolDate is only supported for LTA versions, but was set on non-LTA release: " + release.getVersion());
+      });
   }
 
   private static String toMajorMinor(Release release) {

--- a/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
+++ b/sonar-update-center-common/src/test/java/org/sonar/updatecenter/common/UpdateCenterSerializerTest.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class UpdateCenterSerializerTest {
 
@@ -170,6 +171,30 @@ public class UpdateCenterSerializerTest {
     // legacy scalar fields are kept in sync by the deserializer, not the serializer;
     // the serializer only writes whatever is set on Sonar#getLtaVersion()/getPastLtaVersion()
     assertThat(properties.getProperty("ltaVersion")).isNull();
+  }
+
+  @Test
+  public void toProperties_shouldThrowException_whenPremiumEolDateIsSetOnNonLtaRelease() {
+    Sonar sonar = new Sonar();
+    Release ltaRelease = new Release(sonar, Version.create("2026.1.3"));
+    ltaRelease.setProduct(Product.OLD_SONARQUBE);
+    ltaRelease.setEolDate(FormatUtils.toDate("2027-01-27"));
+    ltaRelease.setPremiumEolDate(FormatUtils.toDate("2027-08-01"));
+    sonar.addRelease(ltaRelease);
+    sonar.setLtaVersions(Arrays.asList(ltaRelease));
+
+    Release nonLtaRelease = new Release(sonar, Version.create("2026.3.0"));
+    nonLtaRelease.setProduct(Product.OLD_SONARQUBE);
+    nonLtaRelease.setPremiumEolDate(FormatUtils.toDate("2027-01-01"));
+    sonar.addRelease(nonLtaRelease);
+
+    PluginReferential pluginReferential = PluginReferential.create(new ArrayList<>());
+    UpdateCenter center = UpdateCenter.create(pluginReferential, new ArrayList<>(), sonar, null);
+
+    assertThatThrownBy(() -> UpdateCenterSerializer.toProperties(center))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("premiumEolDate is only supported for LTA versions")
+      .hasMessageContaining("2026.3.0");
   }
 
   @Test


### PR DESCRIPTION
## What

Adds a fast-fail guard in `UpdateCenterSerializer` that throws `IllegalStateException` when `premiumEolDate` is set on a non-LTA release and serialization is attempted.

## Why

`premiumEolDate` is intended exclusively for LTA lines. Without this guard, setting it on a non-LTA release would silently be ignored during serialization — making the intention of the feature unclear and the misconfiguration hard to diagnose. Failing fast at serialization time makes the constraint explicit and visible.

## Changes

- **`UpdateCenterSerializer`**: after writing LTA EOL dates, validates that no release outside `ltaVersions` has `premiumEolDate` set. Throws with a clear message naming the offending version.
- **`UpdateCenterSerializerTest`**: new test asserting the exception is thrown with the expected message when a non-LTA release has `premiumEolDate`.

## Note

This PR also carries the `setLtaEolDates` + `PREMIUM_EOL_DATE_SUFFIX` writing from the merged PR #181, since master hasn't been updated yet after that merge.